### PR TITLE
Increase precision to match Simplecov results

### DIFF
--- a/lib/simplecov-cobertura.rb
+++ b/lib/simplecov-cobertura.rb
@@ -160,7 +160,7 @@ module SimpleCov
         end
 
         def extract_rate(percent)
-          (percent / 100).round(2).to_s
+          (percent / 100).round(4).to_s
         end
 
         def project_root

--- a/test/simplecov-cobertura_test.rb
+++ b/test/simplecov-cobertura_test.rb
@@ -17,7 +17,13 @@ class CoberturaFormatterTest < Test::Unit::TestCase
             [:if, 3, 5, 4, 5, 26] =>
           {[:then, 4, 5, 16, 5, 20] => 1, [:else, 5, 5, 23, 5, 26] => 0},
             [:if, 6, 7, 4, 11, 7] =>
-          {[:then, 7, 8, 6, 8, 10] => 0, [:else, 8, 10, 6, 10, 9] => 1}
+          {[:then, 7, 8, 6, 8, 10] => 0, [:else, 8, 10, 6, 10, 9] => 1},
+            [:if, 9, 12, 4, 12, 15] =>
+          {[:then, 10, 12, 6, 12, 10] => 1, [:else, 11, 12, 13, 12, 15] => 0},
+            [:if, 12, 13, 4, 13, 20] =>
+          {[:then, 13, 13, 6, 13, 15] => 1, [:else, 14, 13, 18, 13, 20] => 0},
+            [:if, 15, 15, 4, 15, 25] =>
+          {[:then, 16, 15, 6, 15, 20] => 0, [:else, 17, 15, 23, 15, 25] => 0}
         }
       }
     })
@@ -65,12 +71,12 @@ class CoberturaFormatterTest < Test::Unit::TestCase
     doc = Nokogiri::XML::Document.parse(xml)
 
     coverage = doc.xpath '/coverage'
-    assert_equal '0.86', coverage.attribute('line-rate').value
-    assert_equal '0.5', coverage.attribute('branch-rate').value
+    assert_equal '0.8571', coverage.attribute('line-rate').value
+    assert_equal '0.4167', coverage.attribute('branch-rate').value
     assert_equal '6', coverage.attribute('lines-covered').value
     assert_equal '7', coverage.attribute('lines-valid').value
-    assert_equal '3', coverage.attribute('branches-covered').value
-    assert_equal '6', coverage.attribute('branches-valid').value
+    assert_equal '5', coverage.attribute('branches-covered').value
+    assert_equal '12', coverage.attribute('branches-valid').value
     assert_equal '0', coverage.attribute('complexity').value
     assert_equal '0', coverage.attribute('version').value
     assert_not_empty coverage.attribute('timestamp').value
@@ -83,8 +89,8 @@ class CoberturaFormatterTest < Test::Unit::TestCase
     assert_equal 1, packages.length
     package = packages.first
     assert_equal 'simplecov-cobertura', package.attribute('name').value
-    assert_equal '0.86', package.attribute('line-rate').value
-    assert_equal '0.5', package.attribute('branch-rate').value
+    assert_equal '0.8571', package.attribute('line-rate').value
+    assert_equal '0.4167', package.attribute('branch-rate').value
     assert_equal '0', package.attribute('complexity').value
 
     classes = doc.xpath '/coverage/packages/package/classes/class'
@@ -92,8 +98,8 @@ class CoberturaFormatterTest < Test::Unit::TestCase
     clazz = classes.first
     assert_equal 'test/simplecov-cobertura_test.rb', clazz.attribute('name').value
     assert_equal 'test/simplecov-cobertura_test.rb', clazz.attribute('filename').value
-    assert_equal '0.86', clazz.attribute('line-rate').value
-    assert_equal '0.5', clazz.attribute('branch-rate').value
+    assert_equal '0.8571', clazz.attribute('line-rate').value
+    assert_equal '0.4167', clazz.attribute('branch-rate').value
     assert_equal '0', clazz.attribute('complexity').value
 
     lines = doc.xpath '/coverage/packages/package/classes/class/lines/line'
@@ -115,12 +121,12 @@ class CoberturaFormatterTest < Test::Unit::TestCase
     doc = Nokogiri::XML::Document.parse(xml)
 
     coverage = doc.xpath '/coverage'
-    assert_equal '0.86', coverage.attribute('line-rate').value
-    assert_equal '0.5', coverage.attribute('branch-rate').value
+    assert_equal '0.8571', coverage.attribute('line-rate').value
+    assert_equal '0.4167', coverage.attribute('branch-rate').value
     assert_equal '6', coverage.attribute('lines-covered').value
     assert_equal '7', coverage.attribute('lines-valid').value
-    assert_equal '3', coverage.attribute('branches-covered').value
-    assert_equal '6', coverage.attribute('branches-valid').value
+    assert_equal '5', coverage.attribute('branches-covered').value
+    assert_equal '12', coverage.attribute('branches-valid').value
     assert_equal '0', coverage.attribute('complexity').value
     assert_equal '0', coverage.attribute('version').value
     assert_not_empty coverage.attribute('timestamp').value
@@ -133,8 +139,8 @@ class CoberturaFormatterTest < Test::Unit::TestCase
     assert_equal 1, packages.length
     package = packages.first
     assert_equal 'test_group', package.attribute('name').value
-    assert_equal '0.86', package.attribute('line-rate').value
-    assert_equal '0.5', package.attribute('branch-rate').value
+    assert_equal '0.8571', package.attribute('line-rate').value
+    assert_equal '0.4167', package.attribute('branch-rate').value
     assert_equal '0', package.attribute('complexity').value
 
     classes = doc.xpath '/coverage/packages/package/classes/class'
@@ -142,8 +148,8 @@ class CoberturaFormatterTest < Test::Unit::TestCase
     clazz = classes.first
     assert_equal 'test/simplecov-cobertura_test.rb', clazz.attribute('name').value
     assert_equal 'test/simplecov-cobertura_test.rb', clazz.attribute('filename').value
-    assert_equal '0.86', clazz.attribute('line-rate').value
-    assert_equal '0.5', clazz.attribute('branch-rate').value
+    assert_equal '0.8571', clazz.attribute('line-rate').value
+    assert_equal '0.4167', clazz.attribute('branch-rate').value
     assert_equal '0', clazz.attribute('complexity').value
 
     lines = doc.xpath '/coverage/packages/package/classes/class/lines/line'


### PR DESCRIPTION
Sample XML:

```xml
<?xml version='1.0'?>
<!DOCTYPE coverage SYSTEM "http://cobertura.sourceforge.net/xml/coverage-04.dtd">
<!-- Generated by simplecov-cobertura version 3.0.1-dev (https://github.com/jessebs/simplecov-cobertura) -->
<coverage line-rate="0.8571" lines-covered="6" lines-valid="7" branches-covered="5" branches-valid="12" branch-rate="0.4167" complexity="0" version="0" timestamp="1753739500">
  <sources>
    <source>/Users/al/code/simplecov-cobertura</source>
  </sources>
  <packages>
    <package name="simplecov-cobertura" line-rate="0.8571" branch-rate="0.4167" complexity="0">
      <classes>
        <class name="test/simplecov-cobertura_test.rb" filename="test/simplecov-cobertura_test.rb" line-rate="0.8571" branch-rate="0.4167" complexity="0">
          <methods/>
          <lines>
            <line number="1" hits="1" branch="false"/>
            <line number="2" hits="1" branch="false"/>
            <line number="3" hits="1" branch="true" condition-coverage="100% (1/1)"/>
            <line number="5" hits="1" branch="true" condition-coverage="100% (1/1)"/>
            <line number="7" hits="1" branch="false"/>
            <line number="8" hits="0" branch="true" condition-coverage="0% (0/1)"/>
            <line number="10" hits="1" branch="true" condition-coverage="100% (1/1)"/>
          </lines>
        </class>
      </classes>
    </package>
  </packages>
</coverage>
```